### PR TITLE
Increase events' descriptions' max length to 4096

### DIFF
--- a/data/migrations/20200524164137_events.js
+++ b/data/migrations/20200524164137_events.js
@@ -4,7 +4,7 @@ exports.up = async function (knex) {
     //primary table with events
     table.string('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     table.string('name').notNullable();
-    table.string('description', 256).notNullable();
+    table.string('description', 4096).notNullable();
     table.string('location').notNullable();
     table.string('when').notNullable();
   });


### PR DESCRIPTION
I kept getting HTTP 500 errors for having a description that wouldn't quite fit in a modern tweet. This patch expands the Description to hold up to 4K worth of verbiage.